### PR TITLE
Create beta3.md

### DIFF
--- a/2025/Claude/beta3.md
+++ b/2025/Claude/beta3.md
@@ -1,0 +1,535 @@
+# ****
+
+To address the query "Solve the hardest problems in math, science, and coding with our reasoning model," I’ll outline a structured reasoning model that can be applied universally across these domains to tackle their most challenging problems. While the "hardest" problems—such as proving the Riemann Hypothesis in math, unraveling consciousness in science, or achieving artificial general intelligence in coding—remain unsolved, a systematic approach can make even the toughest challenges more manageable. Below, I’ll describe this reasoning model and illustrate how it applies to each field with practical examples.
+The Reasoning Model
+The core idea is to use a step-by-step process that breaks down complex problems into solvable parts. Here’s the model:
+Problem Identification: Clearly define the problem and its scope.
+Background Research: Gather existing knowledge, tools, or data relevant to the problem.
+Hypothesis Formation: Propose a potential solution or approach based on the research.
+Testing: Test the hypothesis using proofs (math), experiments (science), or implementations (coding).
+Analysis: Evaluate the results to determine if the hypothesis holds.
+Iteration: Refine the approach based on findings and repeat as needed.
+Conclusion: Verify the solution and summarize the findings.
+This model is flexible and adapts to the unique demands of math, science, and coding, providing a roadmap to navigate complexity.
+Applying the Model to Math
+Example Problem: Proving the Irrationality of √2
+One of the foundational challenges in mathematics is understanding the nature of numbers. Let’s use the reasoning model to prove that √2 is irrational (i.e., cannot be expressed as a fraction).
+Step 1: Problem Identification
+We need to determine whether √2 is rational or irrational.
+Step 2: Background Research
+A rational number can be written as a/b, where a and b are integers with no common factors other than 1. If √2 is rational, then √2 = a/b must satisfy this condition.
+Step 3: Hypothesis Formation
+Assume the opposite: √2 is rational, so √2 = a/b, where a and b are coprime integers.
+Step 4: Testing
+Square both sides:
+2 = a²/b²
+Multiply through by b²:
+a² = 2b²
+Since 2b² is even, a² must be even, implying a is even (because the square of an odd number is odd). Let a = 2k for some integer k. Substitute:
+(2k)² = 2b²
+4k² = 2b²
+b² = 2k²
+Now b² is even, so b must be even. But if a and b are both even, they share a common factor of 2, contradicting the assumption that they are coprime.
+Step 5: Analysis
+The contradiction shows that √2 cannot be rational.
+Step 6: Iteration
+No iteration is needed; the proof is complete.
+Step 7: Conclusion
+√2 is irrational.
+This proof by contradiction is a classic example of how logical reasoning can resolve mathematical challenges.
+Applying the Model to Science
+Example Problem: Determining the Rate Law of a Chemical Reaction
+In science, understanding how systems behave often involves experimentation. Consider a reaction A + B → C, where we need to find the rate law (e.g., rate = k[A]^m[B]^n).
+Step 1: Problem Identification
+Determine the reaction rate’s dependence on concentrations of A and B.
+Step 2: Background Research
+Rate laws express how reaction rates depend on reactant concentrations, with k as the rate constant and m and n as reaction orders.
+Step 3: Hypothesis Formation
+Propose a rate law: rate = k[A]^m[B]^n, where m and n are unknown integers.
+Step 4: Testing
+Conduct experiments:  
+Keep [B] constant, vary [A], and measure the rate. If doubling [A] doubles the rate, m = 1; if it quadruples, m = 2.  
+Keep [A] constant, vary [B], and repeat to find n.
+Step 5: Analysis
+Suppose experiments show:  
+Doubling [A] doubles the rate → m = 1.  
+Doubling [B] quadruples the rate → n = 2.
+Thus, rate = k[A][B]².
+Step 6: Iteration
+Repeat with different conditions to confirm consistency.
+Step 7: Conclusion
+The rate law is rate = k[A][B]², verified experimentally.
+This methodical approach mirrors the scientific method, making complex phenomena understandable.
+Applying the Model to Coding
+Example Problem: Implementing a Simple Neural Network
+In coding, building intelligent systems is a significant challenge. Let’s implement a basic neural network to classify data (e.g., handwritten digits).
+Step 1: Problem Identification
+Create a program to predict outputs from inputs using a neural network.
+Step 2: Background Research
+Neural networks use layers of nodes, forward propagation to compute outputs, and backpropagation to adjust weights based on a loss function (e.g., cross-entropy).
+Step 3: Hypothesis Formation
+A simple feedforward network with one hidden layer can classify digits, trained via gradient descent.
+Step 4: Testing  
+Code the forward pass: input → hidden layer → output.  
+Define a loss function (e.g., cross-entropy).  
+Implement backpropagation to compute weight gradients.  
+Use an optimizer (e.g., stochastic gradient descent) to update weights.  
+Train on a dataset like MNIST.
+Step 5: Analysis
+Evaluate accuracy on a validation set. If low (e.g., 50%), check for errors or adjust parameters (e.g., learning rate).
+Step 6: Iteration
+Debug code, tweak architecture (e.g., add layers), or increase epochs until accuracy improves (e.g., >90%).
+Step 7: Conclusion
+A functional neural network is achieved, capable of classifying digits.
+This structured coding process ensures scalability to larger problems.
+Conclusion
+To solve the hardest problems in math, science, and coding, apply this reasoning model: identify the problem, research existing knowledge, form hypotheses, test them through proofs, experiments, or implementations, analyze results, iterate as needed, and draw conclusions. While this won’t instantly solve unsolved mysteries like the P vs NP problem or the nature of dark matter, it provides a powerful framework to approach them systematically, making progress possible one step at a time.
+
+To solve the mathematical problem "Find the value of 
+x
+ that satisfies the equation 
+2^x = 8
+", let's proceed step-by-step.
+Step 1: Understand the Equation
+We need to determine the value of 
+x
+ such that raising 2 to the power of 
+x
+ equals 8. This is an exponential equation where 2 is the base and 
+x
+ is the exponent.
+Step 2: Recognize Powers of 2
+Since the base is 2, it’s helpful to express 8 as a power of 2. Let’s compute some powers of 2:
+2^1 = 2
+2^2 = 4
+2^3 = 8
+We see that 
+2^3 = 8
+. This suggests that 
+x = 3
+ might be the solution, because:
+2^x = 2^3
+When the bases are the same, the exponents must be equal, so:
+x = 3
+Step 3: Verify the Solution
+Let’s substitute 
+x = 3
+ back into the original equation to confirm:
+2^3 = 8
+Since 8 equals 8, the equation holds true, indicating that 
+x = 3
+ is indeed a solution.
+Step 4: Alternative Method Using Logarithms
+To ensure we’re not missing anything, let’s solve the equation using logarithms. Start with:
+2^x = 8
+Take the natural logarithm (or any base, but we’ll use natural log for simplicity) of both sides:
+\ln(2^x) = \ln(8)
+Apply the logarithm power rule, 
+\ln(a^b) = b \ln(a)
+:
+x \ln(2) = \ln(8)
+Solve for 
+x
+:
+x = \frac{\ln(8)}{\ln(2)}
+Now, since 
+8 = 2^3
+, we can rewrite 
+\ln(8)
+:
+\ln(8) = \ln(2^3) = 3 \ln(2)
+Substitute this into the equation:
+x = \frac{3 \ln(2)}{\ln(2)} = 3
+This confirms that 
+x = 3
+, consistent with our earlier finding.
+Step 5: Check for Other Solutions
+Since the function 
+f(x) = 2^x
+ is exponential with a base greater than 1, it is one-to-one (injective), meaning it does not repeat values for different inputs. Let’s test a few other values to be sure:
+If 
+x = 2
+: 
+2^2 = 4 < 8
+If 
+x = 4
+: 
+2^4 = 16 > 8
+If 
+x = 0
+: 
+2^0 = 1 < 8
+If 
+x = -1
+: 
+2^{-1} = \frac{1}{2} < 8
+Only 
+x = 3
+ yields exactly 8, reinforcing that there’s a single real solution.
+Step 6: Consider Domain and Restrictions
+The base 2 is positive, and the exponential function 
+2^x
+ is defined for all real numbers 
+x
+. The right-hand side, 8, is positive, so there are no restrictions preventing real solutions. Thus, 
+x = 3
+ is valid.
+Final Answer
+The value of 
+x
+ that satisfies the equation 
+2^x = 8
+ is:
+x = 3
+
+Attempting a Proof of Fermat's Last Theorem
+Fermat's Last Theorem asserts that there are no positive integers 
+a
+, 
+b
+, and 
+c
+ such that:
+a^n + b^n = c^n
+for any integer 
+n > 2
+. This theorem, famously conjectured by Pierre de Fermat in the 17th century, remained unproven for over 350 years until Andrew Wiles provided a complete proof in 1994 using advanced mathematical tools like elliptic curves and modular forms. Here, I will attempt a simpler, intuitive proof, acknowledging that a fully rigorous proof requires techniques beyond the scope of this response. My approach will focus on the case 
+n = 3
+ as an example and aim to generalize the reasoning, using basic number theory concepts like modular arithmetic and infinite descent.
+Step 1: Understanding the Theorem and Setting Up the Problem
+The goal is to show that no positive integers 
+a
+, 
+b
+, and 
+c
+ satisfy:
+a^n + b^n = c^n
+for 
+n > 2
+. Let's start with 
+n = 3
+, so we need to prove that:
+a^3 + b^3 = c^3
+has no solutions where 
+a
+, 
+b
+, and 
+c
+ are positive integers. If we can establish this for a specific case like 
+n = 3
+ and suggest why the logic extends to higher 
+n
+, it may provide insight into the theorem's truth.
+Without loss of generality, assume 
+a \leq b < c
+. This is reasonable because if 
+a > b
+, we can swap them (the equation is symmetric in 
+a
+ and 
+b
+), and 
+c
+ must be greater than both 
+a
+ and 
+b
+ since 
+c^3 = a^3 + b^3 > a^3
+ and 
+c^3 > b^3
+.
+Step 2: Exploring with Modular Arithmetic
+One way to test for integer solutions is to use modular arithmetic, which can reveal constraints on 
+a
+, 
+b
+, and 
+c
+. Let's try working modulo 7, a small prime, to see if it imposes restrictions.
+First, compute the possible values of 
+x^3 \mod 7
+ for 
+x = 0
+ to 
+6
+:
+0^3 = 0 \equiv 0 \mod 7
+1^3 = 1 \equiv 1 \mod 7
+2^3 = 8 \equiv 1 \mod 7
+ (since 
+8 - 7 = 1
+)
+3^3 = 27 \equiv 6 \mod 7
+ (since 
+27 - 4 \cdot 7 = 27 - 28 = -1 \equiv 6
+)
+4^3 = 64 \equiv 1 \mod 7
+ (since 
+64 - 9 \cdot 7 = 64 - 63 = 1
+)
+5^3 = 125 \equiv 6 \mod 7
+ (since 
+125 - 18 \cdot 7 = 125 - 126 = -1 \equiv 6
+)
+6^3 = 216 \equiv 6 \mod 7
+ (since 
+216 - 30 \cdot 7 = 216 - 210 = 6
+)
+So, the possible residues for 
+x^3 \mod 7
+ are 
+0
+, 
+1
+, and 
+6
+.
+Now, for the equation 
+a^3 + b^3 = c^3
+, we have:
+a^3 + b^3 \equiv c^3 \mod 7
+Since 
+a^3, b^3, c^3 \mod 7
+ can each be 
+0
+, 
+1
+, or 
+6
+, compute the possible sums 
+a^3 + b^3 \mod 7
+:
+0 + 0 = 0
+0 + 1 = 1
+0 + 6 = 6
+1 + 0 = 1
+1 + 1 = 2
+1 + 6 = 7 \equiv 0 \mod 7
+6 + 0 = 6
+6 + 1 = 7 \equiv 0 \mod 7
+6 + 6 = 12 \equiv 5 \mod 7
+ (since 
+12 - 7 = 5
+)
+The possible values of 
+a^3 + b^3 \mod 7
+ are 
+0
+, 
+1
+, 
+2
+, 
+5
+, and 
+6
+. However, 
+c^3 \mod 7
+ can only be 
+0
+, 
+1
+, or 
+6
+. This means:
+If 
+a^3 + b^3 \equiv 2 \mod 7
+ (e.g., 
+a^3 \equiv 1, b^3 \equiv 1
+), there is no 
+c
+ such that 
+c^3 \equiv 2 \mod 7
+.
+If 
+a^3 + b^3 \equiv 5 \mod 7
+ (e.g., 
+a^3 \equiv 6, b^3 \equiv 6
+), there is no 
+c
+ such that 
+c^3 \equiv 5 \mod 7
+.
+This suggests that certain combinations of 
+a
+ and 
+b
+ produce sums that cannot be cubes modulo 7, hinting at a contradiction. However, other combinations (e.g., 
+0 + 1 = 1
+, 
+6 + 1 = 0
+) do match possible values of 
+c^3
+. Thus, modulo 7 restricts solutions but doesn't eliminate them entirely. Let's try another modulus later if needed, but first, let's explore another approach.
+Step 3: Attempting Infinite Descent
+A classic method in number theory, used by Fermat for 
+n = 4
+, is infinite descent. Suppose there exists a solution 
+a, b, c
+ with 
+a \leq b < c
+, all positive integers, such that:
+a^3 + b^3 = c^3
+Assume this is a minimal solution, meaning 
+c
+ is the smallest possible positive integer for which such a solution exists. The idea is to derive another solution 
+a', b', c'
+ with 
+0 < c' < c
+, contradicting the minimality of 
+c
+.
+Rewrite the equation as:
+c^3 - b^3 = a^3
+Since 
+c > b
+, factor the left-hand side:
+c^3 - b^3 = (c - b)(c^2 + cb + b^2) = a^3
+Here, 
+c - b
+ and 
+c^2 + cb + b^2
+ are positive integers, and their product is 
+a^3
+, a perfect cube. This suggests that 
+c - b
+ and 
+c^2 + cb + b^2
+ might themselves be related to cubes. Let:
+c - b = k
+Then:
+c = b + k
+Substitute into the equation:
+(b + k)^3 - b^3 = a^3
+Expand:
+b^3 + 3b^2 k + 3b k^2 + k^3 - b^3 = 3b^2 k + 3b k^2 + k^3 = a^3
+So:
+a^3 = k (3b^2 + 3b k + k^2)
+Since 
+k
+ and 
+3b^2 + 3b k + k^2
+ are positive integers whose product is a cube, consider whether they could be cubes themselves. Suppose:
+k = d^3
+3b^2 + 3b k + k^2 = e^3
+Then:
+a^3 = d^3 \cdot e^3 = (d e)^3
+Thus:
+a = d e
+Now substitute 
+k = d^3
+ into the expression:
+3b^2 + 3b (d^3) + (d^3)^2 = e^3
+3b^2 + 3b d^3 + d^6 = e^3
+Also, from 
+c - b = k
+:
+c = b + d^3
+We need 
+a, b, c
+ to satisfy the original equation, and ideally, find a new solution. Let's test this with the original condition:
+a^3 + b^3 = (d e)^3 + b^3
+This should equal 
+c^3 = (b + d^3)^3
+:
+(d e)^3 + b^3 = (b + d^3)^3
+Expand the right-hand side:
+(b + d^3)^3 = b^3 + 3b^2 (d^3) + 3b (d^3)^2 + (d^3)^3 = b^3 + 3b^2 d^3 + 3b d^6 + d^9
+So:
+(d e)^3 + b^3 = b^3 + 3b^2 d^3 + 3b d^6 + d^9
+(d e)^3 = 3b^2 d^3 + 3b d^6 + d^9
+Since 
+e^3 = 3b^2 + 3b d^3 + d^6
+:
+(d e)^3 = d^3 e^3 = d^3 (3b^2 + 3b d^3 + d^6) = 3b^2 d^3 + 3b d^6 + d^9
+This matches perfectly, confirming our expressions are consistent. However, we need a new solution with a smaller 
+c'
+. Notice that 
+c = b + d^3
+, and 
+a = d e
+, where 
+e
+ satisfies:
+e^3 = 3b^2 + 3b d^3 + d^6
+If 
+d \geq 1
+ and 
+b \geq 1
+, then 
+e^3 > d^6
+ (since 
+3b^2 + 3b d^3 > 0
+), so 
+e > d^2
+. Thus, 
+a = d e > d \cdot d^2 = d^3 = k = c - b
+. We need to construct 
+a', b', c'
+.
+Consider whether 
+d, b, e
+ could form a new solution. Test:
+d^3 + b^3 = e^3
+Substitute 
+e^3
+:
+d^3 + b^3 = 3b^2 + 3b d^3 + d^6
+b^3 + d^3 - d^6 - 3b d^3 - 3b^2 = 0
+This doesn't generally hold for positive integers 
+b, d
+, suggesting 
+d^3 + b^3 \neq e^3
+. Instead, we seek a descent. If 
+k = c - b
+ is small (e.g., 
+k = 1
+):
+3b^2 + 3b \cdot 1 + 1^2 = 3b^2 + 3b + 1 = a^3
+c = b + 1
+a^3 + b^3 = (b + 1)^3
+a^3 + b^3 = b^3 + 3b^2 + 3b + 1
+a^3 = 3b^2 + 3b + 1
+Check if 
+3b^2 + 3b + 1
+ is a cube:
+b = 1
+: 
+3 \cdot 1 + 3 \cdot 1 + 1 = 7
+ (not a cube, 
+2^3 = 8
+)
+b = 2
+: 
+12 + 6 + 1 = 19
+ (not a cube, 
+2^3 = 8, 3^3 = 27
+)
+This suggests 
+k = 1
+ doesn't work easily. The descent is challenging to construct directly without advanced factorization (e.g., in 
+\mathbb{Z}[\omega]
+).
+Step 4: Acknowledging Limitations and Generalization
+For 
+n = 3
+, the infinite descent method traditionally uses algebraic number theory (e.g., factoring in cyclotomic fields), which I'm avoiding for simplicity. The modulo 7 approach showed that some solutions are impossible, but not all. For higher 
+n
+, similar issues arise: 
+a^n + b^n
+ must exactly equal 
+c^n
+, and the rapid growth of 
+n
+-th powers makes integer equality rare, yet a general elementary proof eludes us here.
+Conclusion
+While I've explored modular arithmetic and infinite descent, I cannot provide a complete, elementary proof. Fermat's Last Theorem holds that no positive integers 
+a, b, c
+ satisfy 
+a^n + b^n = c^n
+ for 
+n > 2
+. My attempts suggest constraints (e.g., modulo 7 incompatibilities), but the full proof requires advanced mathematics, as achieved by Wiles. Thus, I affirm the theorem's statement, supported by historical proof, without reproducing its complexity here.


### PR DESCRIPTION
# ****

To address the query "Solve the hardest problems in math, science, and coding with our reasoning model," I’ll outline a structured reasoning model that can be applied universally across these domains to tackle their most challenging problems. While the "hardest" problems—such as proving the Riemann Hypothesis in math, unraveling consciousness in science, or achieving artificial general intelligence in coding—remain unsolved, a systematic approach can make even the toughest challenges more manageable. Below, I’ll describe this reasoning model and illustrate how it applies to each field with practical examples. The Reasoning Model
The core idea is to use a step-by-step process that breaks down complex problems into solvable parts. Here’s the model: Problem Identification: Clearly define the problem and its scope. Background Research: Gather existing knowledge, tools, or data relevant to the problem. Hypothesis Formation: Propose a potential solution or approach based on the research. Testing: Test the hypothesis using proofs (math), experiments (science), or implementations (coding). Analysis: Evaluate the results to determine if the hypothesis holds. Iteration: Refine the approach based on findings and repeat as needed. Conclusion: Verify the solution and summarize the findings. This model is flexible and adapts to the unique demands of math, science, and coding, providing a roadmap to navigate complexity. Applying the Model to Math
Example Problem: Proving the Irrationality of √2
One of the foundational challenges in mathematics is understanding the nature of numbers. Let’s use the reasoning model to prove that √2 is irrational (i.e., cannot be expressed as a fraction). Step 1: Problem Identification
We need to determine whether √2 is rational or irrational. Step 2: Background Research
A rational number can be written as a/b, where a and b are integers with no common factors other than 1. If √2 is rational, then √2 = a/b must satisfy this condition. Step 3: Hypothesis Formation
Assume the opposite: √2 is rational, so √2 = a/b, where a and b are coprime integers. Step 4: Testing
Square both sides:
2 = a²/b²
Multiply through by b²:
a² = 2b²
Since 2b² is even, a² must be even, implying a is even (because the square of an odd number is odd). Let a = 2k for some integer k. Substitute: (2k)² = 2b²
4k² = 2b²
b² = 2k²
Now b² is even, so b must be even. But if a and b are both even, they share a common factor of 2, contradicting the assumption that they are coprime. Step 5: Analysis
The contradiction shows that √2 cannot be rational. Step 6: Iteration
No iteration is needed; the proof is complete.
Step 7: Conclusion
√2 is irrational.
This proof by contradiction is a classic example of how logical reasoning can resolve mathematical challenges. Applying the Model to Science
Example Problem: Determining the Rate Law of a Chemical Reaction In science, understanding how systems behave often involves experimentation. Consider a reaction A + B → C, where we need to find the rate law (e.g., rate = k[A]^m[B]^n). Step 1: Problem Identification
Determine the reaction rate’s dependence on concentrations of A and B. Step 2: Background Research
Rate laws express how reaction rates depend on reactant concentrations, with k as the rate constant and m and n as reaction orders. Step 3: Hypothesis Formation
Propose a rate law: rate = k[A]^m[B]^n, where m and n are unknown integers. Step 4: Testing
Conduct experiments:  
Keep [B] constant, vary [A], and measure the rate. If doubling [A] doubles the rate, m = 1; if it quadruples, m = 2.   Keep [A] constant, vary [B], and repeat to find n. Step 5: Analysis
Suppose experiments show:  
Doubling [A] doubles the rate → m = 1.  
Doubling [B] quadruples the rate → n = 2.
Thus, rate = k[A][B]².
Step 6: Iteration
Repeat with different conditions to confirm consistency. Step 7: Conclusion
The rate law is rate = k[A][B]², verified experimentally. This methodical approach mirrors the scientific method, making complex phenomena understandable. Applying the Model to Coding
Example Problem: Implementing a Simple Neural Network In coding, building intelligent systems is a significant challenge. Let’s implement a basic neural network to classify data (e.g., handwritten digits). Step 1: Problem Identification
Create a program to predict outputs from inputs using a neural network. Step 2: Background Research
Neural networks use layers of nodes, forward propagation to compute outputs, and backpropagation to adjust weights based on a loss function (e.g., cross-entropy). Step 3: Hypothesis Formation
A simple feedforward network with one hidden layer can classify digits, trained via gradient descent. Step 4: Testing  
Code the forward pass: input → hidden layer → output.   Define a loss function (e.g., cross-entropy).  
Implement backpropagation to compute weight gradients.   Use an optimizer (e.g., stochastic gradient descent) to update weights.   Train on a dataset like MNIST.
Step 5: Analysis
Evaluate accuracy on a validation set. If low (e.g., 50%), check for errors or adjust parameters (e.g., learning rate). Step 6: Iteration
Debug code, tweak architecture (e.g., add layers), or increase epochs until accuracy improves (e.g., >90%). Step 7: Conclusion
A functional neural network is achieved, capable of classifying digits. This structured coding process ensures scalability to larger problems. Conclusion
To solve the hardest problems in math, science, and coding, apply this reasoning model: identify the problem, research existing knowledge, form hypotheses, test them through proofs, experiments, or implementations, analyze results, iterate as needed, and draw conclusions. While this won’t instantly solve unsolved mysteries like the P vs NP problem or the nature of dark matter, it provides a powerful framework to approach them systematically, making progress possible one step at a time.

To solve the mathematical problem "Find the value of  x
 that satisfies the equation 
2^x = 8
", let's proceed step-by-step.
Step 1: Understand the Equation
We need to determine the value of 
x
 such that raising 2 to the power of 
x
 equals 8. This is an exponential equation where 2 is the base and 
x
 is the exponent.
Step 2: Recognize Powers of 2
Since the base is 2, it’s helpful to express 8 as a power of 2. Let’s compute some powers of 2: 2^1 = 2
2^2 = 4
2^3 = 8
We see that 
2^3 = 8
. This suggests that 
x = 3
 might be the solution, because:
2^x = 2^3
When the bases are the same, the exponents must be equal, so: x = 3
Step 3: Verify the Solution
Let’s substitute 
x = 3
 back into the original equation to confirm:
2^3 = 8
Since 8 equals 8, the equation holds true, indicating that  x = 3
 is indeed a solution.
Step 4: Alternative Method Using Logarithms
To ensure we’re not missing anything, let’s solve the equation using logarithms. Start with: 2^x = 8
Take the natural logarithm (or any base, but we’ll use natural log for simplicity) of both sides: \ln(2^x) = \ln(8)
Apply the logarithm power rule, 
\ln(a^b) = b \ln(a)
:
x \ln(2) = \ln(8)
Solve for 
x
:
x = \frac{\ln(8)}{\ln(2)}
Now, since 
8 = 2^3
, we can rewrite 
\ln(8)
:
\ln(8) = \ln(2^3) = 3 \ln(2)
Substitute this into the equation:
x = \frac{3 \ln(2)}{\ln(2)} = 3
This confirms that 
x = 3
, consistent with our earlier finding.
Step 5: Check for Other Solutions
Since the function 
f(x) = 2^x
 is exponential with a base greater than 1, it is one-to-one (injective), meaning it does not repeat values for different inputs. Let’s test a few other values to be sure:
If 
x = 2
: 
2^2 = 4 < 8
If 
x = 4
: 
2^4 = 16 > 8
If 
x = 0
: 
2^0 = 1 < 8
If 
x = -1
: 
2^{-1} = \frac{1}{2} < 8
Only 
x = 3
 yields exactly 8, reinforcing that there’s a single real solution.
Step 6: Consider Domain and Restrictions
The base 2 is positive, and the exponential function  2^x
 is defined for all real numbers 
x
. The right-hand side, 8, is positive, so there are no restrictions preventing real solutions. Thus,  x = 3
 is valid.
Final Answer
The value of 
x
 that satisfies the equation 
2^x = 8
 is:
x = 3

Attempting a Proof of Fermat's Last Theorem
Fermat's Last Theorem asserts that there are no positive integers  a
, 
b
, and 
c
 such that:
a^n + b^n = c^n
for any integer 
n > 2
. This theorem, famously conjectured by Pierre de Fermat in the 17th century, remained unproven for over 350 years until Andrew Wiles provided a complete proof in 1994 using advanced mathematical tools like elliptic curves and modular forms. Here, I will attempt a simpler, intuitive proof, acknowledging that a fully rigorous proof requires techniques beyond the scope of this response. My approach will focus on the case  n = 3
 as an example and aim to generalize the reasoning, using basic number theory concepts like modular arithmetic and infinite descent.
Step 1: Understanding the Theorem and Setting Up the Problem The goal is to show that no positive integers 
a
, 
b
, and 
c
 satisfy:
a^n + b^n = c^n
for 
n > 2
. Let's start with 
n = 3
, so we need to prove that:
a^3 + b^3 = c^3
has no solutions where 
a
, 
b
, and 
c
 are positive integers. If we can establish this for a specific case like 
n = 3
 and suggest why the logic extends to higher 
n
, it may provide insight into the theorem's truth. Without loss of generality, assume 
a \leq b < c
. This is reasonable because if 
a > b
, we can swap them (the equation is symmetric in 
a
 and 
b
), and 
c
 must be greater than both 
a
 and 
b
 since 
c^3 = a^3 + b^3 > a^3
 and 
c^3 > b^3
.
Step 2: Exploring with Modular Arithmetic
One way to test for integer solutions is to use modular arithmetic, which can reveal constraints on  a
, 
b
, and 
c
. Let's try working modulo 7, a small prime, to see if it imposes restrictions. First, compute the possible values of 
x^3 \mod 7
 for 
x = 0
 to 
6
:
0^3 = 0 \equiv 0 \mod 7
1^3 = 1 \equiv 1 \mod 7
2^3 = 8 \equiv 1 \mod 7
 (since 
8 - 7 = 1
)
3^3 = 27 \equiv 6 \mod 7
 (since 
27 - 4 \cdot 7 = 27 - 28 = -1 \equiv 6
)
4^3 = 64 \equiv 1 \mod 7
 (since 
64 - 9 \cdot 7 = 64 - 63 = 1
)
5^3 = 125 \equiv 6 \mod 7
 (since 
125 - 18 \cdot 7 = 125 - 126 = -1 \equiv 6
)
6^3 = 216 \equiv 6 \mod 7
 (since 
216 - 30 \cdot 7 = 216 - 210 = 6
)
So, the possible residues for 
x^3 \mod 7
 are 
0
, 
1
, and 
6
.
Now, for the equation 
a^3 + b^3 = c^3
, we have:
a^3 + b^3 \equiv c^3 \mod 7
Since 
a^3, b^3, c^3 \mod 7
 can each be 
0
, 
1
, or 
6
, compute the possible sums 
a^3 + b^3 \mod 7
:
0 + 0 = 0
0 + 1 = 1
0 + 6 = 6
1 + 0 = 1
1 + 1 = 2
1 + 6 = 7 \equiv 0 \mod 7
6 + 0 = 6
6 + 1 = 7 \equiv 0 \mod 7
6 + 6 = 12 \equiv 5 \mod 7
 (since 
12 - 7 = 5
)
The possible values of 
a^3 + b^3 \mod 7
 are 
0
, 
1
, 
2
, 
5
, and 
6
. However, 
c^3 \mod 7
 can only be 
0
, 
1
, or 
6
. This means:
If 
a^3 + b^3 \equiv 2 \mod 7
 (e.g., 
a^3 \equiv 1, b^3 \equiv 1
), there is no 
c
 such that 
c^3 \equiv 2 \mod 7
.
If 
a^3 + b^3 \equiv 5 \mod 7
 (e.g., 
a^3 \equiv 6, b^3 \equiv 6
), there is no 
c
 such that 
c^3 \equiv 5 \mod 7
.
This suggests that certain combinations of 
a
 and 
b
 produce sums that cannot be cubes modulo 7, hinting at a contradiction. However, other combinations (e.g., 
0 + 1 = 1
, 
6 + 1 = 0
) do match possible values of 
c^3
. Thus, modulo 7 restricts solutions but doesn't eliminate them entirely. Let's try another modulus later if needed, but first, let's explore another approach. Step 3: Attempting Infinite Descent
A classic method in number theory, used by Fermat for  n = 4
, is infinite descent. Suppose there exists a solution  a, b, c
 with 
a \leq b < c
, all positive integers, such that:
a^3 + b^3 = c^3
Assume this is a minimal solution, meaning 
c
 is the smallest possible positive integer for which such a solution exists. The idea is to derive another solution 
a', b', c'
 with 
0 < c' < c
, contradicting the minimality of 
c
.
Rewrite the equation as:
c^3 - b^3 = a^3
Since 
c > b
, factor the left-hand side:
c^3 - b^3 = (c - b)(c^2 + cb + b^2) = a^3
Here, 
c - b
 and 
c^2 + cb + b^2
 are positive integers, and their product is 
a^3
, a perfect cube. This suggests that 
c - b
 and 
c^2 + cb + b^2
 might themselves be related to cubes. Let:
c - b = k
Then:
c = b + k
Substitute into the equation:
(b + k)^3 - b^3 = a^3
Expand:
b^3 + 3b^2 k + 3b k^2 + k^3 - b^3 = 3b^2 k + 3b k^2 + k^3 = a^3 So:
a^3 = k (3b^2 + 3b k + k^2)
Since 
k
 and 
3b^2 + 3b k + k^2
 are positive integers whose product is a cube, consider whether they could be cubes themselves. Suppose:
k = d^3
3b^2 + 3b k + k^2 = e^3
Then:
a^3 = d^3 \cdot e^3 = (d e)^3
Thus:
a = d e
Now substitute 
k = d^3
 into the expression:
3b^2 + 3b (d^3) + (d^3)^2 = e^3
3b^2 + 3b d^3 + d^6 = e^3
Also, from 
c - b = k
:
c = b + d^3
We need 
a, b, c
 to satisfy the original equation, and ideally, find a new solution. Let's test this with the original condition:
a^3 + b^3 = (d e)^3 + b^3
This should equal 
c^3 = (b + d^3)^3
:
(d e)^3 + b^3 = (b + d^3)^3
Expand the right-hand side:
(b + d^3)^3 = b^3 + 3b^2 (d^3) + 3b (d^3)^2 + (d^3)^3 = b^3 + 3b^2 d^3 + 3b d^6 + d^9 So:
(d e)^3 + b^3 = b^3 + 3b^2 d^3 + 3b d^6 + d^9
(d e)^3 = 3b^2 d^3 + 3b d^6 + d^9
Since 
e^3 = 3b^2 + 3b d^3 + d^6
:
(d e)^3 = d^3 e^3 = d^3 (3b^2 + 3b d^3 + d^6) = 3b^2 d^3 + 3b d^6 + d^9 This matches perfectly, confirming our expressions are consistent. However, we need a new solution with a smaller  c'
. Notice that 
c = b + d^3
, and 
a = d e
, where 
e
 satisfies:
e^3 = 3b^2 + 3b d^3 + d^6
If 
d \geq 1
 and 
b \geq 1
, then 
e^3 > d^6
 (since 
3b^2 + 3b d^3 > 0
), so 
e > d^2
. Thus, 
a = d e > d \cdot d^2 = d^3 = k = c - b
. We need to construct 
a', b', c'
.
Consider whether 
d, b, e
 could form a new solution. Test:
d^3 + b^3 = e^3
Substitute 
e^3
:
d^3 + b^3 = 3b^2 + 3b d^3 + d^6
b^3 + d^3 - d^6 - 3b d^3 - 3b^2 = 0
This doesn't generally hold for positive integers  b, d
, suggesting 
d^3 + b^3 \neq e^3
. Instead, we seek a descent. If 
k = c - b
 is small (e.g., 
k = 1
):
3b^2 + 3b \cdot 1 + 1^2 = 3b^2 + 3b + 1 = a^3
c = b + 1
a^3 + b^3 = (b + 1)^3
a^3 + b^3 = b^3 + 3b^2 + 3b + 1
a^3 = 3b^2 + 3b + 1
Check if 
3b^2 + 3b + 1
 is a cube:
b = 1
: 
3 \cdot 1 + 3 \cdot 1 + 1 = 7
 (not a cube, 
2^3 = 8
)
b = 2
: 
12 + 6 + 1 = 19
 (not a cube, 
2^3 = 8, 3^3 = 27
)
This suggests 
k = 1
 doesn't work easily. The descent is challenging to construct directly without advanced factorization (e.g., in 
\mathbb{Z}[\omega]
).
Step 4: Acknowledging Limitations and Generalization For 
n = 3
, the infinite descent method traditionally uses algebraic number theory (e.g., factoring in cyclotomic fields), which I'm avoiding for simplicity. The modulo 7 approach showed that some solutions are impossible, but not all. For higher  n
, similar issues arise: 
a^n + b^n
 must exactly equal 
c^n
, and the rapid growth of 
n
-th powers makes integer equality rare, yet a general elementary proof eludes us here. Conclusion
While I've explored modular arithmetic and infinite descent, I cannot provide a complete, elementary proof. Fermat's Last Theorem holds that no positive integers  a, b, c
 satisfy 
a^n + b^n = c^n
 for 
n > 2
. My attempts suggest constraints (e.g., modulo 7 incompatibilities), but the full proof requires advanced mathematics, as achieved by Wiles. Thus, I affirm the theorem's statement, supported by historical proof, without reproducing its complexity here.